### PR TITLE
ci(release): enable Windows (.msi/.exe) desktop packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Desktop release
 # Builds the ForgeaX Studio desktop app installers and attaches them to a GitHub
 # Release. Runs ONLY on a version tag (v*) or manual dispatch — never on every push.
 #
-# macOS is wired up today (mirrors the local `bun fx build app` path). Windows is
-# scaffolded but commented until the sidecar/build is validated there. The produced
-# installers are unsigned dev builds for now — see docs/desktop distribution notes
-# for signing/notarization before a public 1.0.
+# macOS and Windows are both wired up (mirroring the local `bun fx build app`
+# path). The Windows job is newly enabled and may need iteration on the bun
+# sidecar / tauri build path. The produced installers are unsigned dev builds for
+# now — see docs/desktop distribution notes for signing/notarization before 1.0.
 on:
   push:
     tags: ["v*"]
@@ -59,19 +59,45 @@ jobs:
           path: dist/*
           if-no-files-found: warn
 
-  # windows:
-  #   name: Windows (.msi) — WIP
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with: { submodules: recursive }
-  #     - uses: oven-sh/setup-bun@v2
-  #     - uses: actions/setup-node@v4
-  #       with: { node-version: "22" }
-  #     - uses: pnpm/action-setup@v4
-  #       with: { version: 9 }
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - uses: taiki-e/install-action@v2
-  #       with: { tool: wasm-pack }
-  #     - run: bun fx setup
-  #     # Windows packaging needs a bun sidecar + tauri build path validated first.
+  windows:
+    name: Windows (.msi / .exe)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with: { node-version: "22" }
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with: { tool: wasm-pack }
+      - name: Install + build engine (bun fx setup)
+        run: bun fx setup
+        env:
+          FORGEAX_SKIP_HARNESS_SYNC: "1"
+      - name: Package desktop app (bun fx build app)
+        run: bun fx build app
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p dist
+          BUNDLE="packages/interface/src-tauri/target/release/bundle"
+          cp "$BUNDLE/msi/"*.msi dist/ 2>/dev/null || true
+          cp "$BUNDLE/nsis/"*.exe dist/ 2>/dev/null || true
+          ls -lh dist || true
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          fail_on_unmatched_files: false
+      - name: Upload as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: forgeax-studio-windows
+          path: dist/*
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
         with: { tool: wasm-pack }
+      - name: Install rsync (build-desktop.sh assembles Resources via rsync)
+        shell: pwsh
+        run: choco install -y --no-progress rsync
       - name: Install + build engine (bun fx setup)
         run: bun fx setup
         env:


### PR DESCRIPTION
Enables the previously-commented Windows job in the Desktop release workflow, completing it with build + artifact collection (.msi/.exe) + release upload, mirroring the macOS job.

Note: Windows packaging was marked WIP upstream (bun sidecar / tauri path unvalidated); a dispatch run on this branch is used to validate it end-to-end.